### PR TITLE
Support AMQPS protocol 

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,7 +16,8 @@ FROM fluent/fluent-bit:1.3
 LABEL maintainer="Björn Franke"
 
 COPY --from=building-stage /go/src/out_rabbitmq.so  /fluent-bit/bin/
+COPY ./conf/fluent-bit-docker.conf /fluent-bit/etc
 
 EXPOSE 2020
 
-CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf","-e","/fluent-bit/bin/out_rabbitmq.so"]
+CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit-docker.conf","-e","/fluent-bit/bin/out_rabbitmq.so"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -16,8 +16,7 @@ FROM fluent/fluent-bit:1.3
 LABEL maintainer="Björn Franke"
 
 COPY --from=building-stage /go/src/out_rabbitmq.so  /fluent-bit/bin/
-COPY ./conf/fluent-bit-docker.conf /fluent-bit/etc
 
 EXPOSE 2020
 
-CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit-docker.conf","-e","/fluent-bit/bin/out_rabbitmq.so"]
+CMD ["/fluent-bit/bin/fluent-bit", "-c", "/fluent-bit/etc/fluent-bit.conf","-e","/fluent-bit/bin/out_rabbitmq.so"]

--- a/README.md
+++ b/README.md
@@ -25,7 +25,7 @@ build
 | RoutingKey                   | The routing-key pattern                                                                          | ""            |
 | RoutingKeyDelimiter          | The Delemiter which seperates the routing-key parts                                              |  "."          |
 | RemoveRkValuesFromRecord     | If enabled fluentd deletes the values of the record,  which have been stored in the routing-key  | ""            |
-| AMQPS                        | If enabled fluent bit will attempt to connecto to RabbitMQ via the amqps protocol instead of amqp| "false"       |
+| AMQPS                        | If enabled fluent bit will attempt to connect to RabbitMQ via the amqps protocol instead of amqp| "false"       |
 
 ### Routing-Key pattern
 

--- a/README.md
+++ b/README.md
@@ -14,17 +14,18 @@ build
 
 ### Configuration-Parameter
 
-| Parameter                    | Description                                                                                     | Default-Value |
-|------------------------------|-------------------------------------------------------------------------------------------------|---------------|
-| RabbitHost                   | The hostname of the Rabbit-MQ server                                                            | ""            |
-| RabbitPort                   | The port under which the Rabbit-MQ is reachable                                                 | ""            |
-| RabbitUser                   | The user of the Rabbit-MQ host                                                                  | ""            |
-| RabbitPassword               | The username of the user which connects to the Rabbit-MQ server                                 | ""            |
-| ExchangeName                 | The exchange to which fluent-bit send its logs                                                  | ""            |
-| ExchangeType                 | The exchange-type                                                                               | ""            |
-| RoutingKey                   | The routing-key pattern                                                                         | ""            |
-| RoutingKeyDelimiter          | The Delemiter which seperates the routing-key parts                                             |  "."          |
-| RemoveRkValuesFromRecord     | If enabled fluentd deletes the values of the record,  which have been stored in the routing-key | ""            |
+| Parameter                    | Description                                                                                      | Default-Value |
+|------------------------------|--------------------------------------------------------------------------------------------------|---------------|
+| RabbitHost                   | The hostname of the Rabbit-MQ server                                                             | ""            |
+| RabbitPort                   | The port under which the Rabbit-MQ is reachable                                                  | ""            |
+| RabbitUser                   | The user of the Rabbit-MQ host                                                                   | ""            |
+| RabbitPassword               | The username of the user which connects to the Rabbit-MQ server                                  | ""            |
+| ExchangeName                 | The exchange to which fluent-bit send its logs                                                   | ""            |
+| ExchangeType                 | The exchange-type                                                                                | ""            |
+| RoutingKey                   | The routing-key pattern                                                                          | ""            |
+| RoutingKeyDelimiter          | The Delemiter which seperates the routing-key parts                                              |  "."          |
+| RemoveRkValuesFromRecord     | If enabled fluentd deletes the values of the record,  which have been stored in the routing-key  | ""            |
+| AMQPS                        | If enabled fluent bit will attempt to connecto to RabbitMQ via the amqps protocol instead of amqp| "false"       |
 
 ### Routing-Key pattern
 

--- a/out_rabbitmq.go
+++ b/out_rabbitmq.go
@@ -20,7 +20,7 @@ var (
 	removeRkValuesFromRecord bool
 	addTagToRecord           bool
 	addTimestampToRecord     bool
-	amqps					 bool
+	amqps                    bool
 )
 
 //export FLBPluginRegister

--- a/out_rabbitmq.go
+++ b/out_rabbitmq.go
@@ -20,6 +20,7 @@ var (
 	removeRkValuesFromRecord bool
 	addTagToRecord           bool
 	addTimestampToRecord     bool
+	amqps					 bool
 )
 
 //export FLBPluginRegister
@@ -44,6 +45,9 @@ func FLBPluginInit(plugin unsafe.Pointer) int {
 	removeRkValuesFromRecordStr := output.FLBPluginConfigKey(plugin, "RemoveRkValuesFromRecord")
 	addTagToRecordStr := output.FLBPluginConfigKey(plugin, "AddTagToRecord")
 	addTimestampToRecordStr := output.FLBPluginConfigKey(plugin, "AddTimestampToRecord")
+	amqpsStr := output.FLBPluginConfigKey(plugin, "AMQPS")
+
+	var urlPrefix = "amqp"
 
 	if len(routingKeyDelimiter) < 1 {
 		routingKeyDelimiter = "."
@@ -74,7 +78,18 @@ func FLBPluginInit(plugin unsafe.Pointer) int {
 		return output.FLB_ERROR
 	}
 
-	connection, err = amqp.Dial("amqp://" + user + ":" + password + "@" + host + ":" + port + "/")
+	amqps, err = strconv.ParseBool(amqpsStr)
+	if len(amqpsStr) == 0 {
+		logInfo("The AMQPS value was not, using default value of 'false', amqp protocol")
+	}
+	if err != nil {
+		logInfo("Couldn't parse amqps to boolean, using amqp")
+	}
+	if err == nil && amqps {
+		urlPrefix = "amqps"
+	}
+
+	connection, err = amqp.Dial(urlPrefix + "://" + user + ":" + password + "@" + host + ":" + port + "/")
 	if err != nil {
 		logError("Failed to establish a connection to RabbitMQ: ", err)
 		return output.FLB_ERROR


### PR DESCRIPTION
When trying to used secure rabbitmq exchanges, you need to be able to connect using amqps instead of amqp. Added an additional parameter to support this and updated docs to reflect that